### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ language: php
 php:
   - '7.2'
   - '7.3'
+  - 'nightly'
+
+matrix:
+  allow_failures:
+    - php: nightly
 
 install:
   - composer install

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,4 +17,10 @@
             <directory>tests/</directory>
         </testsuite>
     </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/tests/Template/ContextTest.php
+++ b/tests/Template/ContextTest.php
@@ -7,7 +7,7 @@ use Petk\Template\Context;
 
 class ContextTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->context = new Context(__DIR__.'/../fixtures/templates');
     }
@@ -18,19 +18,19 @@ class ContextTest extends TestCase
         echo 'bar';
         $this->context->end('foo');
 
-        $this->assertEquals($this->context->block('foo'), 'bar');
+        $this->assertEquals('bar', $this->context->block('foo'));
 
         $this->context->append('foo');
         echo 'baz';
         $this->context->end('foo');
 
-        $this->assertEquals($this->context->block('foo'), 'barbaz');
+        $this->assertEquals('barbaz', $this->context->block('foo'));
 
         $this->context->start('foo');
         echo 'overridden';
         $this->context->end('foo');
 
-        $this->assertEquals($this->context->block('foo'), 'overridden');
+        $this->assertEquals('overridden', $this->context->block('foo'));
     }
 
     public function testInclude()
@@ -47,6 +47,19 @@ class ContextTest extends TestCase
         $variable = $this->context->include('includes/variable.php');
 
         $this->assertEquals(include __DIR__.'/../fixtures/templates/includes/variable.php', $variable);
+    }
+
+    public function testIncludeOnInvalidVariableCounts()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Variables with numeric names $0, $1... cannot be imported to scope includes/variable.php');
+
+        $this->context->include('includes/variable.php', ['var1', 'var2', 'var3']);
+    }
+
+    public function testCallOnUndefinedMethod()
+    {
+        $this->assertNull($this->context->undefinedMethod());
     }
 
     /**

--- a/tests/Template/EngineTest.php
+++ b/tests/Template/EngineTest.php
@@ -7,9 +7,19 @@ use Petk\Template\Engine;
 
 class EngineTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->template = new Engine(__DIR__.'/../fixtures/templates');
+    }
+
+    public function testConstructorOnNonExistedDorectory()
+    {
+        $nonExistedDirectory = './non/existed/directory';
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage($nonExistedDirectory.' is missing or not a valid directory.');
+
+        new Engine($nonExistedDirectory);
     }
 
     public function testView()
@@ -48,6 +58,7 @@ class EngineTest extends TestCase
     public function testRegisterExisting()
     {
         $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('oHtml is already registered by the template engine. Use a different name.');
 
         $this->template->register('noHtml', function ($var) {
             return $var;
@@ -111,8 +122,9 @@ class EngineTest extends TestCase
         ]);
 
         $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Variables with numeric names $0, $1... cannot be imported to scope pages/invalid_variables.php');
 
-        $content = $this->template->render('pages/invalid_variables.php', [
+        $this->template->render('pages/invalid_variables.php', [
             'foo' => 'Lorem ipsum dolor sit amet',
             1 => 'Invalid overridden value with key 1',
         ]);
@@ -172,8 +184,9 @@ class EngineTest extends TestCase
         ]);
 
         $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('pages/this/does/not/exist.php is missing or not a valid template.');
 
-        $content = $this->template->render('pages/this/does/not/exist.php', [
+        $this->template->render('pages/this/does/not/exist.php', [
             'foo' => 'Lorem ipsum dolor sit amet',
         ]);
     }
@@ -181,7 +194,8 @@ class EngineTest extends TestCase
     public function testExtending()
     {
         $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Extending includes/base.php is not possible.');
 
-        $html = $this->template->render('pages/extends.php');
+        $this->template->render('pages/extends.php');
     }
 }


### PR DESCRIPTION
# Changed log
- Add `php-nightly` test and allow this to be failed.
- Add the white filter list in `phpunit.xml.dist` setting to evaluate the code coverage status.
- Remove variables that are declared, but not used.
- Add other tests to test other methods.
- According to the [PHPUnit Fixtures reference](https://phpunit.readthedocs.io/en/latest/fixtures.html?highlight=fixtures), the `PHPUnit\Framework\TestCase::setUp` method should be `protected`, not `public`.